### PR TITLE
Make field $args more specific & flexible

### DIFF
--- a/src/Field/Multicolor.php
+++ b/src/Field/Multicolor.php
@@ -66,7 +66,8 @@ class Multicolor extends Field {
 						'parent_setting' => $args['settings'],
 						'label'          => '',
 						'description'    => $choice_label,
-						'default'        => isset( $args['default'][ $choice ] ) ? $args['default'][ $choice ] : '',
+						'default'        => $this->filter_preferred_choice_setting( 'default', $choice, $args ),
+						'input_attrs'    => $this->filter_preferred_choice_setting( 'input_attrs', $choice, $args ),
 						'css_vars'       => [],
 						'output'         => [],
 					],
@@ -74,6 +75,38 @@ class Multicolor extends Field {
 				)
 			);
 		}
+	}
+	
+	/**
+	 * Prefer control specific value over field value
+	 *
+	 * @access public
+	 * @since 4.0
+	 * @param $setting
+	 * @param $choice
+	 * @param $args
+	 *
+	 * @return string
+	 */
+	public function filter_preferred_choice_setting( $setting, $choice, $args ) {
+		// Fail early
+		if ( ! isset( $args[ $setting ] ) ) {
+			return '';
+		}
+
+		// If a specific field for the choice is set
+		if ( isset( $args[ $setting ][ $choice ] ) ) {
+			return $args[ $setting ][ $choice ];
+		}
+
+		// Unset input_attrs of all other choices
+		foreach ( $args['choices'] as $id => $set ) {
+			if ( $id !== $choice ) {
+				unset( $args[ $setting ][ $id ] );
+			}
+		}
+
+		return $args[ $setting ];
 	}
 
 	/**

--- a/src/Field/Multicolor.php
+++ b/src/Field/Multicolor.php
@@ -68,6 +68,9 @@ class Multicolor extends Field {
 						'description'    => $choice_label,
 						'default'        => $this->filter_preferred_choice_setting( 'default', $choice, $args ),
 						'input_attrs'    => $this->filter_preferred_choice_setting( 'input_attrs', $choice, $args ),
+						'choices'        => [
+							'alpha' => $this->filter_preferred_choice_setting( 'alpha', $choice, $args ),
+						],
 						'css_vars'       => [],
 						'output'         => [],
 					],


### PR DESCRIPTION
Dear @aristath,
I am currently working on a Module for Kirki that requires setting `'input_attrs'` specific for a control. Currently when settings it e.g. for a multicolor field the same value is copied to each color control. That makes the following scenario impossible.

````
'choices'   => [
	'menu_item'   => esc_attr__( 'Menu Item Color', 'domain' ),
	'menu_item_hover' => esc_attr__( 'Menu Item Hover & Active', 'domain' ),
],
'input_attrs' => [
	'menu_item_hover' => [
		'data-my-test' => 'The data-my-test value',
	],
],
````

This PR allows defining `'input_attrs'` for all controls at once (as it is currently the case) as well as setting it specific for a single control - as in my example above. I wrote it to be usable also with other fields and changed it in the PR also for the `'default'` `$arg`. This allows (vice versa) to define the default for all control at once or for each separately.

Looking forward to read your feedback,

Philipp