### PR TITLE
Fix PHP error: "Array to string conversion"

### DIFF
--- a/src/Field/Multicolor.php
+++ b/src/Field/Multicolor.php
@@ -47,9 +47,10 @@ class Multicolor extends Field {
 		new \Kirki\Field\Generic(
 			wp_parse_args(
 				[
-					'type'    => 'kirki-generic',
-					'default' => '',
-					'choices' => [
+					'type'        => 'kirki-generic',
+					'default'     => '',
+					'input_attrs' => '',
+					'choices'     => [
 						'type' => 'hidden',
 					],
 				],


### PR DESCRIPTION
Fixes PHP error if 'input_attrs' is set as array.