### PR TITLE
Prevent breaking with wrong naming conventions

### DIFF
--- a/src/Field/Multicolor.php
+++ b/src/Field/Multicolor.php
@@ -103,8 +103,10 @@ class Multicolor extends Field {
 
 		// Unset input_attrs of all other choices
 		foreach ( $args['choices'] as $id => $set ) {
-			if ( $id !== $choice ) {
+			if ( $id !== $choice && isset( $args[ $setting ][ $id ] ) ) {
 				unset( $args[ $setting ][ $id ] );
+			} else if ( ! isset( $args[ $setting ][ $id ] ) ) {
+				$args[ $setting ] = '';
 			}
 		}
 


### PR DESCRIPTION
Prevents PHP error if array key from `$args[ 'choices '][ $key ]` and `$args[ $setting ][ $key ]` are different. Until now it was not unset from the array as it was not found.